### PR TITLE
LAR-05: Allow Users to Update Their Own Reminder

### DIFF
--- a/src/app/Http/Controllers/Api/ReminderController.php
+++ b/src/app/Http/Controllers/Api/ReminderController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\EAV\Entities\ReminderEntity;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreReminderRequest;
+use App\Http\Requests\UpdateReminderRequest;
 use App\Http\Resources\ReminderResource;
 use App\Repositories\Repository;
 
@@ -37,6 +38,26 @@ class ReminderController extends Controller
             'user_id' => $request->user()->id,
             ...$values,
         ]);
+
+        return new ReminderResource(
+            new ReminderEntity(
+                $reminder->id,
+                $reminder->title,
+                $reminder->description,
+                $reminder->remind_at,
+                $reminder->event_at
+            )
+        );
+    }
+
+    /**
+     * Handle update existing reminder resource by id.
+     */
+    public function update(UpdateReminderRequest $request): ReminderResource
+    {
+        $values = $request->only(['title', 'description', 'remind_at', 'event_at']);
+
+        $reminder = $this->repository->update($request->id, $values);
 
         return new ReminderResource(
             new ReminderEntity(

--- a/src/app/Http/Requests/StoreReminderRequest.php
+++ b/src/app/Http/Requests/StoreReminderRequest.php
@@ -2,23 +2,12 @@
 
 namespace App\Http\Requests;
 
-use App\Http\Resources\ErrorResource;
-use App\Services\AuthService;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Http\Exceptions\HttpResponseException;
-use Illuminate\Validation\ValidationException;
 
 class StoreReminderRequest extends FormRequest
 {
-    /**
-     * Determine if the user is authorized to make this request.
-     */
-    public function authorize(): bool
-    {
-        return AuthService::isAllowToMakeRequest($this->user());
-    }
+    use WithAccessApi, WithCustomFailedValidation;
 
     /**
      * Get the validation rules that apply to the request.
@@ -33,19 +22,5 @@ class StoreReminderRequest extends FormRequest
             'remind_at' => ['required', 'date_format:U', 'lt:event_at'],
             'event_at' => ['required', 'date_format:U', 'gt:remind_at'],
         ];
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    protected function failedValidation(Validator $validator): void
-    {
-        if ($this->expectsJson()) {
-            $resource = new ErrorResource(new ValidationException($validator));
-
-            throw new HttpResponseException($resource->toResponse($this));
-        }
-
-        parent::failedValidation($validator);
     }
 }

--- a/src/app/Http/Requests/UpdateReminderRequest.php
+++ b/src/app/Http/Requests/UpdateReminderRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Rules\EventReminderRule;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateReminderRequest extends FormRequest
+{
+    use WithAccessApi, WithCustomFailedValidation;
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => ['bail', 'exists:reminders,id'],
+            'title' => ['nullable'],
+            'description' => ['nullable'],
+            'remind_at' => ['nullable', 'date_format:U', new EventReminderRule($this->id, $this->get('event_at'))],
+            'event_at' => ['nullable', 'date_format:U', new EventReminderRule($this->id, $this->get('remind_at'))],
+        ];
+    }
+
+    /**
+     * Prepare the data for validation.
+     *
+     * @return void
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge(['id' => $this->id]);
+    }
+}

--- a/src/app/Http/Requests/WithAccessApi.php
+++ b/src/app/Http/Requests/WithAccessApi.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Services\AuthService;
+
+/**
+ * @method user() Get the user making the request
+ */
+trait WithAccessApi
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return AuthService::isAllowToMakeRequest($this->user());
+    }
+}

--- a/src/app/Http/Requests/WithCustomFailedValidation.php
+++ b/src/app/Http/Requests/WithCustomFailedValidation.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Http\Resources\ErrorResource;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * @extends FormRequest
+ * @method expectsJson()
+ */
+trait WithCustomFailedValidation
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function failedValidation(Validator $validator): void
+    {
+        if ($this->expectsJson()) {
+            $resource = new ErrorResource(new ValidationException($validator));
+
+            throw new HttpResponseException($resource->toResponse($this));
+        }
+
+        parent::failedValidation($validator);
+    }
+}

--- a/src/app/Http/Resources/ErrorResource.php
+++ b/src/app/Http/Resources/ErrorResource.php
@@ -13,6 +13,22 @@ use Symfony\Component\HttpFoundation\Response;
 class ErrorResource extends JsonResource
 {
     /**
+     * Get HTTP error status code base on error values
+     */
+    public function getStatusCode(): int
+    {
+        if ($this->resource === 'api.login') {
+            return Response::HTTP_UNAUTHORIZED;
+        }
+
+        if (array_key_exists('id', $this->resource->errors())) {
+            return Response::HTTP_NOT_FOUND;
+        }
+
+        return Response::HTTP_BAD_REQUEST;
+    }
+
+    /**
      * Transform the resource into an array.
      *
      * @return array<string, mixed>
@@ -30,7 +46,7 @@ class ErrorResource extends JsonResource
         }
 
         if ($this->resource instanceof ValidationException) {
-            return (new HttpErrorEntity($this->resource->errors()))->toArray();
+            return (new HttpErrorEntity($this->resource->errors(), $this->getStatusCode()))->toArray();
         }
 
         return parent::toArray($request);
@@ -38,10 +54,6 @@ class ErrorResource extends JsonResource
 
     public function withResponse(Request $request, JsonResponse $response): void
     {
-        if ($this->resource === 'api.login') {
-            $response->setStatusCode(Response::HTTP_UNAUTHORIZED);
-        } elseif ($this->resource instanceof ValidationException) {
-            $response->setStatusCode(Response::HTTP_BAD_REQUEST);
-        }
+        $response->setStatusCode($this->getStatusCode());
     }
 }

--- a/src/app/Repositories/ReminderRepository.php
+++ b/src/app/Repositories/ReminderRepository.php
@@ -24,20 +24,6 @@ class ReminderRepository extends Repository
     /**
      * {@inheritDoc}
      */
-    public function toEntity(): ReminderEntity
-    {
-        return new ReminderEntity(
-            $this->model->id,
-            $this->model->title,
-            $this->model->description,
-            $this->model->remind_at,
-            $this->model->event_at
-        );
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function model(): string
     {
         return Reminder::class;

--- a/src/app/Repositories/Repository.php
+++ b/src/app/Repositories/Repository.php
@@ -27,6 +27,31 @@ abstract class Repository
     }
 
     /**
+     * Get one record by id
+     *
+     * @param int $id
+     * @return Model|null
+     */
+    public function find(int $id): ?Model
+    {
+        return $this->model->find($id);
+    }
+
+    /**
+     * Update existing record by id
+     *
+     * @param int $id
+     * @param array $attributes
+     * @return Model
+     */
+    public function update(int $id, array $attributes): Model
+    {
+        $this->find($id)->update($attributes);
+
+        return $this->find($id);
+    }
+
+    /**
      * Get the eloquent model instance
      *
      * @return Model
@@ -42,11 +67,4 @@ abstract class Repository
      * @return string
      */
     abstract public function model(): string;
-
-    /**
-     * Get the eloquent model as entity
-     *
-     * @return Entity
-     */
-    abstract public function toEntity(): Entity;
 }

--- a/src/app/Rules/EventReminderRule.php
+++ b/src/app/Rules/EventReminderRule.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+class EventReminderRule implements ValidationRule
+{
+    /**
+     * Create a new rule instance
+     */
+    public function __construct(public readonly int $id, public readonly int|string|null $target)
+    {
+        //
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (is_null($this->target)) {
+            $reminder = DB::table('reminders')
+                ->select('remind_at', 'event_at')
+                ->where('id', $this->id)
+                ->first();
+
+            if ($attribute === 'remind_at' && $value >= $reminder->event_at) {
+                $fail(__('validation.lt.numeric', ['attribute' => 'remind at', 'value' => $reminder->event_at]));
+            } elseif ($attribute === 'event_at' && $value <= $reminder->remind_at) {
+                $fail(__('validation.gt.numeric', ['attribute' => 'event at', 'value' => $reminder->remind_at]));
+            }
+        } elseif (is_numeric($value)) {
+            if ($attribute === 'remind_at' && $value >= $this->target) {
+                $fail(__('validation.lt.numeric', ['attribute' => 'remind at', 'value' => $this->target]));
+            } elseif ($attribute === 'event_at' && $value <= $this->target) {
+                $fail(__('validation.gt.numeric', ['attribute' => 'event at', 'value' => $this->target]));
+            }
+        }
+    }
+}

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -27,4 +27,5 @@ Route::prefix('session')->group(function (Router $router) {
 
 Route::prefix('reminders')->group(function (Router $router) {
     $router->post('/', [ReminderController::class, 'store'])->name('api.reminder.store');
+    $router->put('{id}', [ReminderController::class, 'update'])->name('api.reminder.update');
 });

--- a/src/tests/Feature/Reminder/UserCanUpdateExistingReminderRecordTest.php
+++ b/src/tests/Feature/Reminder/UserCanUpdateExistingReminderRecordTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Feature\Reminder;
+
+use App\Models\Reminder;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Date;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class UserCanUpdateExistingReminderRecordTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    /** @test */
+    public function can_only_update_reminder_title(): void
+    {
+        $title = $this->faker->jobTitle;
+        $user = User::factory()->create();
+        $reminder = Reminder::factory()->belongsTo($user)->create();
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->putJson("api/reminders/$reminder->id", [
+            'title' => $title,
+        ]);
+
+        $response
+            ->assertStatus(200)
+            ->assertJson([
+                'ok' => true,
+                'data' => [
+                    'title' => $title,
+                    ...$reminder->only('description', 'remind_at', 'event_at'),
+                ],
+            ]);
+    }
+
+    /** @test */
+    public function can_only_update_reminder_description(): void
+    {
+        $description = $this->faker->text;
+        $user = User::factory()->create();
+        $reminder = Reminder::factory()->belongsTo($user)->create();
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->putJson("api/reminders/$reminder->id", [
+            'description' => $description,
+        ]);
+
+        $response
+            ->assertStatus(200)
+            ->assertJson([
+                'ok' => true,
+                'data' => [
+                    'description' => $description,
+                    ...$reminder->only('title', 'remind_at', 'event_at'),
+                ],
+            ]);
+    }
+
+    /** @test */
+    public function can_only_update_reminder_remind_at(): void
+    {
+        $remindAt = Date::now()->format('U');
+        $user = User::factory()->create();
+        $reminder = Reminder::factory()->belongsTo($user)->create([
+            'remind_at' => Date::now()->addDays(1)->format('U'),
+            'event_at' => Date::now()->addDays(3)->format('U'),
+        ]);
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->putJson("api/reminders/$reminder->id", [
+            'remind_at' => $remindAt,
+        ]);
+
+        $response
+            ->assertStatus(200)
+            ->assertJson([
+                'ok' => true,
+                'data' => [
+                    'remind_at' => $remindAt,
+                    ...$reminder->only('title', 'description', 'event_at'),
+                ],
+            ]);
+    }
+
+    /** @test */
+    public function can_only_update_reminder_event_at(): void
+    {
+        $eventAt = Date::now()->addDays(3)->format('U');
+        $user = User::factory()->create();
+        $reminder = Reminder::factory()->belongsTo($user)->create([
+            'remind_at' => Date::now()->format('U'),
+            'event_at' => Date::now()->addDays(1)->format('U'),
+        ]);
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->putJson("api/reminders/$reminder->id", [
+            'event_at' => $eventAt,
+        ]);
+
+        $response
+            ->assertStatus(200)
+            ->assertJson([
+                'ok' => true,
+                'data' => [
+                    'event_at' => $eventAt,
+                    ...$reminder->only('title', 'description', 'remind_at'),
+                ],
+            ]);
+    }
+
+    /** @test */
+    public function can_only_update_all_reminder_fields(): void
+    {
+        Sanctum::actingAs($user = User::factory()->create(), ['access-api']);
+        $reminder = Reminder::factory()->belongsTo($user)->create();
+        $newReminder = [
+            'title' => $this->faker->jobTitle,
+            'description' => $this->faker->text,
+            'remind_at' => Date::now()->addDays(1)->format('U'),
+            'event_at' => Date::now()->addDays(4)->format('U'),
+        ];
+
+        $response = $this->putJson("api/reminders/$reminder->id", $newReminder);
+
+        $response
+            ->assertStatus(200)
+            ->assertJson(['ok' => true, 'data' => $newReminder]);
+    }
+}

--- a/src/tests/Feature/Reminder/ValidateStoreReminderInputTest.php
+++ b/src/tests/Feature/Reminder/ValidateStoreReminderInputTest.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Date;
 use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
 
-class ValidateReminderInputTest extends TestCase
+class ValidateStoreReminderInputTest extends TestCase
 {
     use RefreshDatabase, WithFaker;
 

--- a/src/tests/Feature/Reminder/ValidateUpdateReminderInputTest.php
+++ b/src/tests/Feature/Reminder/ValidateUpdateReminderInputTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Feature\Reminder;
+
+use App\Models\Reminder;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Date;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ValidateUpdateReminderInputTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    /** @test */
+    public function cannot_update_reminder_because_entity_not_found(): void
+    {
+        Date::setTestNow();
+        Sanctum::actingAs(User::factory()->create(), ['access-api']);
+
+        $response = $this->putJson('/api/reminders/1', [
+            'title' => 'Title',
+        ]);
+
+        $response
+            ->assertNotFound()
+            ->assertJson([
+                'ok' => false,
+                'data' => [
+                    'id' => [__('validation.exists', ['attribute' => 'id'])],
+                ],
+                'err' => 'ERR_NOT_FOUND',
+                'msg' => 'resource is not found',
+            ]);
+    }
+
+    /** @test */
+    public function cannot_update_remind_at_n_event_at_when_the_values_are_not_unix_date(): void
+    {
+        Date::setTestNow();
+        Sanctum::actingAs($user = User::factory()->create(), ['access-api']);
+        $reminder = Reminder::factory()->belongsTo($user)->create();
+
+        $response = $this->putJson("/api/reminders/$reminder->id", [
+            'remind_at' => Date::now(),
+            'event_at' => Date::now()->addDays(3),
+        ]);
+
+        $response
+            ->assertBadRequest()
+            ->assertJson([
+                'ok' => false,
+                'data' => [
+                    'remind_at' => [__('validation.date_format', ['attribute' => 'remind at', 'format' => 'U'])],
+                    'event_at' => [__('validation.date_format', ['attribute' => 'event at', 'format' => 'U'])],
+                ],
+                'err' => 'ERR_BAD_REQUEST',
+                'msg' => 'invalid value of remind_at, event_at',
+            ]);
+    }
+
+    /** @test */
+    public function cannot_update_remind_at_if_its_greater_then_existing_event_at(): void
+    {
+        Date::setTestNow();
+        Sanctum::actingAs($user = User::factory()->create(), ['access-api']);
+        $reminder = Reminder::factory()->belongsTo($user)->create([
+            'event_at' => $eventAt = Date::now()->addDays(3)->format('U'),
+        ]);
+
+        $response = $this->putJson("/api/reminders/$reminder->id", [
+            'remind_at' => Date::now()->addDays(4)->format('U'),
+        ]);
+
+        $response
+            ->assertBadRequest()
+            ->assertJson([
+                'ok' => false,
+                'data' => [
+                    'remind_at' => [__('validation.lt.numeric', ['attribute' => 'remind at', 'value' => $eventAt])],
+                ],
+                'err' => 'ERR_BAD_REQUEST',
+                'msg' => 'invalid value of remind_at',
+            ]);
+    }
+
+    /** @test */
+    public function cannot_update_event_at_its_less_then_existing_remind_at(): void
+    {
+        Date::setTestNow();
+        Sanctum::actingAs($user = User::factory()->create(), ['access-api']);
+        $reminder = Reminder::factory()->belongsTo($user)->create([
+            'remind_at' => $remindAt = Date::now()->addDays(3)->format('U'),
+        ]);
+
+        $response = $this->putJson("/api/reminders/$reminder->id", [
+            'event_at' => Date::now()->format('U'),
+        ]);
+
+        $response
+            ->assertBadRequest()
+            ->assertJson([
+                'ok' => false,
+                'data' => [
+                    'event_at' => [__('validation.gt.numeric', ['attribute' => 'event at', 'value' => $remindAt])],
+                ],
+                'err' => 'ERR_BAD_REQUEST',
+                'msg' => 'invalid value of event_at',
+            ]);
+    }
+
+    /** @test */
+    public function cannot_update_remind_at_n_event_at_when_the_values_are_incorrect(): void
+    {
+        Date::setTestNow();
+        Sanctum::actingAs($user = User::factory()->create(), ['access-api']);
+        $reminder = Reminder::factory()->belongsTo($user)->create();
+
+        $response = $this->putJson("/api/reminders/$reminder->id", [
+            'remind_at' => $remindAt = Date::now()->addDays(2)->format('U'),
+            'event_at' => $eventAt = Date::now()->format('U'),
+        ]);
+
+        $response
+            ->assertBadRequest()
+            ->assertJson([
+                'ok' => false,
+                'data' => [
+                    'remind_at' => [__('validation.lt.numeric', ['attribute' => 'remind at', 'value' => $eventAt])],
+                    'event_at' => [__('validation.gt.numeric', ['attribute' => 'event at', 'value' => $remindAt])],
+                ],
+                'err' => 'ERR_BAD_REQUEST',
+                'msg' => 'invalid value of remind_at, event_at',
+            ]);
+    }
+}


### PR DESCRIPTION
As a _**User**_ I want to be able to updating my existing reminder that already stored in the database system. The system should determine which input field that's need to be updated. In other words, I can only submit a specific field without receiving HTTP error response

**ACCEPTANCE CRITERIA**

- [ ] Adding new API endpoint to create reminder using HTTP PUT `(/api/reminders/{id})`.
- [ ] Should validate all input before save the reminder data to database.
- [ ] Only authenticated user can update their reminder's
- [ ] Should implement unit test