### PR TITLE
LAR-06: Handle Show Reminder Request

### DIFF
--- a/src/app/Http/Controllers/Api/ReminderController.php
+++ b/src/app/Http/Controllers/Api/ReminderController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\EAV\Entities\ReminderEntity;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\ShowReminderRequest;
 use App\Http\Requests\StoreReminderRequest;
 use App\Http\Requests\UpdateReminderRequest;
 use App\Http\Resources\ReminderResource;
@@ -25,6 +26,24 @@ class ReminderController extends Controller
     {
         $this->middleware('auth:sanctum');
         $this->repository = $repository;
+    }
+
+    /**
+     * Handle request to view reminder by id
+     */
+    public function show(ShowReminderRequest $request): ReminderResource
+    {
+        $reminder = $this->repository->find($request->id);
+
+        return new ReminderResource(
+            new ReminderEntity(
+                $reminder->id,
+                $reminder->title,
+                $reminder->description,
+                $reminder->remind_at,
+                $reminder->event_at
+            )
+        );
     }
 
     /**

--- a/src/app/Http/Requests/ShowReminderRequest.php
+++ b/src/app/Http/Requests/ShowReminderRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ShowReminderRequest extends FormRequest
+{
+    use WithAccessApi, WithCustomFailedValidation;
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => ['exists:reminders,id'],
+        ];
+    }
+
+    /**
+     * Prepare the data for validation.
+     *
+     * @return void
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge(['id' => $this->id]);
+    }
+}

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -26,6 +26,7 @@ Route::prefix('session')->group(function (Router $router) {
 });
 
 Route::prefix('reminders')->group(function (Router $router) {
+    $router->get('{id}', [ReminderController::class, 'show'])->name('api.reminder.show');
     $router->post('/', [ReminderController::class, 'store'])->name('api.reminder.store');
     $router->put('{id}', [ReminderController::class, 'update'])->name('api.reminder.update');
 });

--- a/src/tests/Feature/Reminder/UserCanShowReminderTest.php
+++ b/src/tests/Feature/Reminder/UserCanShowReminderTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\Reminder;
+
+use App\Models\Reminder;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class UserCanShowReminderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function can_show_reminder_by_id(): void
+    {
+        Sanctum::actingAs($user = User::factory()->create(), ['access-api']);
+        $reminder = Reminder::factory()->belongsTo($user)->create();
+
+        $response = $this->getJson("/api/reminders/$reminder->id");
+
+        $response
+            ->assertOk()
+            ->assertJson([
+                'ok' => true,
+                'data' => $reminder->only('id', 'title', 'description', 'remind_at', 'event_at'),
+            ]);
+    }
+
+    /** @test */
+    public function cannot_show_reminder_by_id_because_resource_not_found(): void
+    {
+        Sanctum::actingAs($user = User::factory()->create(), ['access-api']);
+
+        $response = $this->getJson('/api/reminders/1');
+
+        $response
+            ->assertNotFound()
+            ->assertJson([
+                'ok' => false,
+                'data' => [
+                    'id' => [__('validation.exists', ['attribute' => 'id'])],
+                ],
+                'err' => 'ERR_NOT_FOUND',
+                'msg' => 'resource is not found',
+            ]);
+    }
+}


### PR DESCRIPTION
As a _**User**_ I want to be able to show my reminder's in detail. When I'm selecting specific reminder from web page the system should display all available information regarding the selected reminder.

**ACCEPTANCE CRITERIA**

- [ ] Adding new API endpoint to show reminder by ID using HTTP GET `(/api/reminders/{id})`.
- [ ] Only authenticated user can show their reminder's
- [ ] Should implement unit test